### PR TITLE
Fix debug mode to use debug mode db

### DIFF
--- a/bootstrap_exercises.py
+++ b/bootstrap_exercises.py
@@ -1,16 +1,21 @@
 import json
 import models
 import database
+import argparse
 
-session = database.Session()
 
-exercises = json.load(open('exercises.json', 'r'))
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog="Bootstrap exercises")
+    parser.add_argument('-d', dest='debug', action='store_true', help='Bootstrap to the QA db')
+    args = parser.parse_args()
 
-for category in exercises['exercise_categories']:
-    session.add(models.ExerciseCategory(**category))
-session.commit()
+    session = database.get_connection(args.debug)
+    exercises = json.load(open('exercises.json', 'r'))
 
-for exercise in exercises['exercises']:
-    session.add(models.Exercise(**exercise))
+    for category in exercises['exercise_categories']:
+        session.add(models.ExerciseCategory(**category))
+    session.commit()
 
-session.commit()
+    for exercise in exercises['exercises']:
+        session.add(models.Exercise(**exercise))
+    session.commit()

--- a/database.py
+++ b/database.py
@@ -3,8 +3,12 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 import yaml
 
 
-with open('secrets.yaml') as file:
-    secrets = yaml.load(file)
-    engine = create_engine(secrets['sqlalchemy_connection_string'], echo=True)
+def get_connection(is_debug):
+    with open('secrets.yaml') as file:
+        secrets = yaml.load(file)
+        if is_debug:
+            engine = create_engine(secrets['sqlalchemy_connection_string_qa'], echo=True)
+        else:
+            engine = create_engine(secrets['sqlalchemy_connection_string'], echo=True)
 
-Session = scoped_session(sessionmaker(bind=engine))
+    return scoped_session(sessionmaker(bind=engine))


### PR DESCRIPTION
In secrets.yaml you can now specify both
* sqlalchemy_connection_string
* sqlalchemy_connection_string_qa
If you use the `-d` flag it'll read/write from the qa connection string

This addressed issue #13 