### PR TITLE
Upgrade pyyaml and add MySQL-python dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dbus-python==1.2.4
-PyYAML==3.12
+pyyaml>=4.2b1
 six==1.10.0
 SQLAlchemy==1.1.4
+MySQL-python==1.2.5


### PR DESCRIPTION
Pyyaml has a security vulnerability (github informed me of this)
https://snyk.io/vuln/SNYK-PYTHON-PYYAML-42159
and there was a missing MySQL-python dep in the requirements file