### PR TITLE
Update requirements for python3 and dbus params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Getting started
 
-1. Install the dependencies with `apt install libdbus-1-dev libdbus-glib-1-dev`
-2. First set up your virtualenv (ideally under the conventional "vendor" directory) with `virtualenv vendor`
+1. Install the dependencies with `sudo apt install libdbus-1-dev libdbus-glib-1-dev festival libssl-dev`
+2. Set up your virtualenv (ideally under the conventional "vendor" directory) with `virtualenv vendor`
 3. Activate the virtualenvironment and install the pip requirements with `pip install -r requirements.txt`
 4. Create a `secrets.yaml` file in the format of the secrets.yaml.template in the top level directory. This should hold the connection string to whatever backend you choose to use
 5. To create your database tables, run `init_db.py`

--- a/nerdouts/music.py
+++ b/nerdouts/music.py
@@ -19,8 +19,8 @@ class Player(with_metaclass(Singleton, object)):
 
 class ClementinePlayer(with_metaclass(Singleton, Player)):
     def __init__(self):
-        self._player = dbus.SessionBus().get_object('org.mpris.clementine', '/Player')
-        self._iface = dbus.Interface(self._player, dbus_interface='org.freedesktop.MediaPlayer')
+        self._player = dbus.SessionBus().get_object('org.mpris.MediaPlayer2.clementine', '/org/mpris/MediaPlayer2')
+        self._iface = dbus.Interface(self._player, dbus_interface='org.mpris.MediaPlayer2.Player')
         subprocess.call('clementine -l /home/dseisun/.config/Clementine/Playlists/Workout.xspf', shell=True)
 
     def next(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dbus-python==1.2.4
 pyyaml>=4.2b1
 six==1.10.0
 SQLAlchemy==1.1.4
-MySQL-python==1.2.5
+mysqlclient==1.4.6


### PR DESCRIPTION
New year new version of python. I upgraded my home computer to ubuntu 18.04 so finally bit the bullet and moved to python3 and a newer version of [clementine](https://www.clementine-player.org/)

* Moved to a newer version of a python mysql library that's python3
compatible
* Migrated the dbus interface to the one used in newer versions of
clementine

Closes #24 